### PR TITLE
Fix main entry point for Expo app

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,4 @@
+import { registerRootComponent } from 'expo';
+import App from './App';
+
+registerRootComponent(App);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ridestitch",
   "version": "1.0.0",
-  "main": "index.ts",
+  "main": "index.js",
   "scripts": {
     "start": "expo start",
     "android": "expo start --android",


### PR DESCRIPTION
## Summary
- Create index.js to properly register the App component with Expo
- Update package.json main field from index.ts to index.js
- Resolves HTTP 500 error and "main has not been registered" invariant violation

## Test plan
- [x] App loads successfully in iOS simulator without HTTP 500 error
- [x] App component registers properly without invariant violation
- [x] Expo dev server starts correctly

🤖 Generated with [Claude Code](https://claude.ai/code)